### PR TITLE
Close Allegheny docs and verification gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,15 @@ Run these before opening a pull request:
 make fmt
 make lint
 make type
+make coverage
 make docstrings-check
 make test
 make docs-check
 make docs
 ```
+
+The repository maintains a 90% total coverage floor, and `make coverage`
+enforces that threshold locally using the same JSON-based check as CI.
 
 Optional but useful:
 

--- a/docs/experiments_handoff.rst
+++ b/docs/experiments_handoff.rst
@@ -1,0 +1,132 @@
+Experiments-To-Analysis Handoff
+===============================
+
+Use this guide when you already have study artifacts exported from
+``design-research-experiments`` and want the shortest reliable path into
+analysis.
+
+Why This Handoff Exists
+-----------------------
+
+``design-research-experiments`` exports canonical study artifacts, including
+``events.csv``, ``runs.csv``, and ``evaluations.csv``. In
+``design-research-analysis``, ``events.csv`` is the primary first-class input
+for validation and downstream workflows.
+
+For background on the study-side workflow, see the
+`design-research-experiments typical workflow <https://cmudrc.github.io/design-research-experiments/typical_workflow.html>`_
+and
+`reference overview <https://cmudrc.github.io/design-research-experiments/reference/index.html>`_.
+The current canonical export contract is implemented in
+`design_research_experiments.artifacts <https://github.com/cmudrc/design-research-experiments/blob/main/src/design_research_experiments/artifacts.py>`_.
+
+Canonical Input Files
+---------------------
+
+- ``events.csv``: event-level analysis input for validation, sequence, language,
+  and dimred workflows.
+- ``runs.csv``: run-level study context such as condition, model, seed, status,
+  and outcome metadata.
+- ``evaluations.csv``: evaluator outputs keyed to a run, such as scores or
+  rubric metrics.
+
+Start With ``events.csv``
+-------------------------
+
+Validate the exported table before running analysis-family commands.
+
+.. code-block:: bash
+
+   design-research-analysis validate-table \
+     --input study-output/events.csv \
+     --summary-json artifacts/validate_table.json
+
+Then run one downstream analysis workflow on the same artifact input.
+
+.. code-block:: bash
+
+   design-research-analysis run-sequence \
+     --input study-output/events.csv \
+     --summary-json artifacts/sequence.json \
+     --mode markov
+
+You can use the same validated ``events.csv`` input for language, dimred, and
+stats commands depending on the study question.
+
+Validation And Derivation In Python
+-----------------------------------
+
+.. code-block:: python
+
+   from design_research_analysis import (
+       derive_columns,
+       fit_markov_chain_from_table,
+       validate_unified_table,
+   )
+
+   rows = derive_columns(
+       events_rows,
+       actor_mapper=lambda row: row.get("actor_id") or "agent",
+       event_mapper=lambda row: row.get("event_type") or "event",
+   )
+
+   report = validate_unified_table(rows)
+   if not report.is_valid:
+       raise RuntimeError("; ".join(report.errors))
+
+   result = fit_markov_chain_from_table(rows)
+   print(result.states)
+
+Column Expectations In The Export Handoff
+-----------------------------------------
+
+Required for unified-table validation:
+
+- ``timestamp``
+
+Strongly recommended in exported ``events.csv``:
+
+- ``record_id``
+- ``text``
+- ``session_id``
+- ``actor_id``
+- ``event_type``
+
+Optional but commonly present:
+
+- ``meta_json``
+- ``run_id``
+
+Derived-column guidance:
+
+- Derive ``actor_id`` when the experiment trace uses another participant field.
+- Derive ``event_type`` when raw observations need normalization into a shared
+  event vocabulary.
+- Derive ``record_id`` when upstream events are otherwise stable but unlabeled.
+
+Rejoin Study Context
+--------------------
+
+After analysis, rejoin event-level outputs back to study context.
+
+Preferred join path:
+
+- If ``events.csv`` includes ``run_id``, join on
+  ``events.run_id -> runs.run_id`` and
+  ``events.run_id -> evaluations.run_id``.
+
+Fallback join path:
+
+- If ``run_id`` is absent, join on
+  ``events.session_id -> runs.run_id`` and
+  ``events.session_id -> evaluations.run_id``.
+  The experiments exporter defaults ``session_id`` to the run id when a session
+  id is otherwise missing.
+
+Related Docs
+------------
+
+- :doc:`quickstart`
+- :doc:`typical_workflow`
+- :doc:`unified_table_schema`
+- :doc:`cli_reference`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,9 @@ design-research-analysis
 
 The analysis layer for reproducible design-research event data.
 
+What This Library Does
+----------------------
+
 ``design-research-analysis`` supports sequence analysis, language analysis,
 dimensionality reduction, and statistical modeling over unified event-table
 inputs. It is built for recurring research workflows where validation,
@@ -32,48 +35,32 @@ reproducible, and easier to compare across studies.
      </a>
    </div>
 
+Highlights
+----------
+
+- Unified-table coercion, validation, and mapper-driven derived columns
+- Dataset profiling, schema checks, and codebook generation
+- Sequence analysis for Markov chains and Hidden Markov Models
+- Language analysis for semantic convergence, topic discovery, and sentiment
+- Dimensionality reduction and clustering for embedding-space inspection
+- Statistical workflows for comparisons, regression, mixed effects, and power
+- Runtime provenance capture for reproducible study artifacts
+
+Typical Workflow
+----------------
+
+1. Start from a unified event table or an exported
+   ``design-research-experiments`` ``events.csv`` artifact.
+2. Validate and, when needed, derive missing analysis columns.
+3. Run sequence, language, dimred, and/or statistical workflows.
+4. Persist JSON summaries, CSV exports, and provenance manifests.
+5. Rejoin findings to ``runs.csv`` and ``evaluations.csv`` for study context.
+
 .. note::
 
-   **Start with** :doc:`quickstart` to validate a first event table, run a
-   representative analysis pass, and get the package into a reproducible local
-   loop before diving into the broader workflow and API material.
-
-Guides
-------
-
-Learn the table contract, setup flow, and analysis workflow patterns that
-shape a stable research pipeline.
-
-- :doc:`quickstart`
-- :doc:`installation`
-- :doc:`concepts`
-- :doc:`typical_workflow`
-- :doc:`workflows`
-- :doc:`analysis_recipes`
-
-Examples
---------
-
-Browse runnable examples that show the public API in action across the major
-analysis families.
-
-- :doc:`examples/index`
-- :doc:`examples/basic_usage`
-- :doc:`examples/unified_table_validation`
-- :doc:`examples/sequence_from_table`
-- :doc:`examples/dimred_pca`
-- :doc:`examples/stats_regression`
-
-Reference
----------
-
-Look up the stable import surface, CLI behavior, and documentation for the
-core table contract and optional extras.
-
-- :doc:`api`
-- :doc:`cli_reference`
-- :doc:`unified_table_schema`
-- :doc:`dependencies_and_extras`
+   **Start with** :doc:`quickstart` for the shortest runnable path, or
+   :doc:`experiments_handoff` if you already have ``events.csv`` from
+   ``design-research-experiments``.
 
 Integration With The Ecosystem
 ------------------------------
@@ -100,6 +87,7 @@ Start Here
 - :doc:`quickstart`
 - :doc:`installation`
 - :doc:`concepts`
+- :doc:`experiments_handoff`
 - :doc:`typical_workflow`
 - :doc:`examples/index`
 - :doc:`api`
@@ -107,16 +95,31 @@ Start Here
 
 .. toctree::
    :maxdepth: 2
+   :caption: Documentation
    :hidden:
 
    quickstart
    installation
    concepts
    typical_workflow
-   workflows
-   analysis_recipes
    examples/index
    api
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Development
+   :hidden:
+
+   dependencies_and_extras
+   Contributing <https://github.com/cmudrc/design-research-analysis/blob/main/CONTRIBUTING.md>
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Additional Guides
+   :hidden:
+
+   experiments_handoff
+   workflows
+   analysis_recipes
    unified_table_schema
    cli_reference
-   dependencies_and_extras

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -58,6 +58,7 @@ This demonstrates the package design: schema discipline first, analysis second.
 -------------------
 
 - :doc:`concepts`
+- :doc:`experiments_handoff`
 - :doc:`typical_workflow`
 - :doc:`workflows`
 - :doc:`examples/index`
@@ -69,3 +70,7 @@ In a typical study, ``design-research-agents`` provides executable
 participants, ``design-research-problems`` supplies the task,
 ``design-research-experiments`` defines the study structure, and
 ``design-research-analysis`` interprets the resulting records.
+
+If you are starting from exported study artifacts rather than an in-memory
+table, use :doc:`experiments_handoff` for the recommended ``events.csv`` to
+analysis path.

--- a/docs/typical_workflow.rst
+++ b/docs/typical_workflow.rst
@@ -7,6 +7,10 @@ Typical Workflow
 Load event-table records and identify the study context (conditions, actors,
 outcomes).
 
+If you are working from ``design-research-experiments`` exports, start with
+``events.csv`` and use :doc:`experiments_handoff` for the canonical validation
+and rejoin flow back to ``runs.csv`` and ``evaluations.csv``.
+
 2. Instantiate core objects
 ---------------------------
 

--- a/docs/unified_table_schema.rst
+++ b/docs/unified_table_schema.rst
@@ -8,6 +8,10 @@ The unified table schema is the canonical input contract across all analysis
 families in this package. It enables repeatable pipelines while still allowing
 loose real-world data.
 
+If your input originated in ``design-research-experiments``, see
+:doc:`experiments_handoff` for the recommended ``events.csv`` validation and
+join workflow.
+
 Column Expectations
 -------------------
 
@@ -32,6 +36,10 @@ Loose Schema Strategy
 
 Missing values for ``actor_id`` and ``event_type`` can be derived with
 deterministic mapper functions before running sequence analyses.
+
+In the experiments export handoff, ``record_id`` may also be derived when the
+upstream artifact keeps stable event rows but does not emit explicit record
+identifiers.
 
 Key API surfaces:
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -2,22 +2,43 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 DOCS_DIR = Path("docs")
 INDEX_PATH = DOCS_DIR / "index.rst"
 API_PATH = DOCS_DIR / "api.rst"
 README_PATH = Path("README.md")
+_LABELED_TARGET_RE = re.compile(r"^.+<([^>]+)>$")
+
+
+def _normalize_toctree_target(entry: str) -> str | None:
+    """Normalize one toctree entry into a local docs target, when applicable.
+
+    Args:
+        entry: Raw stripped toctree line.
+
+    Returns:
+        The local target path without a ``.rst`` suffix, or ``None`` for
+        external links.
+    """
+    match = _LABELED_TARGET_RE.match(entry)
+    target = match.group(1).strip() if match else entry.strip()
+    if "://" in target:
+        return None
+    if target.endswith(".rst"):
+        return target[:-4]
+    return target
 
 
 def extract_toctree_entries(index_path: Path) -> tuple[str, ...]:
-    """Extract document entries from the first toctree in `index.rst`.
+    """Extract local document entries from all toctrees in ``index.rst``.
 
     Args:
         index_path: Path to the docs index file.
 
     Returns:
-        The referenced document names without suffixes.
+        The referenced local document names without suffixes.
     """
     entries: list[str] = []
     in_toctree = False
@@ -33,9 +54,11 @@ def extract_toctree_entries(index_path: Path) -> tuple[str, ...]:
         if stripped.startswith(":"):
             continue
         if line.startswith("   "):
-            entries.append(stripped)
+            target = _normalize_toctree_target(stripped)
+            if target is not None:
+                entries.append(target)
             continue
-        break
+        in_toctree = False
     return tuple(entries)
 
 


### PR DESCRIPTION
## Summary
- align the docs landing structure with the shared module baseline while keeping the current PyData theme
- add a dedicated experiments-to-analysis handoff guide centered on `events.csv`
- document the enforced 90% coverage floor and update docs consistency checks for the multi-toctree layout

## Issues
- Addresses #17
- Addresses #21
- Addresses #23

## Validation
- `make docs-check`
- `make docs`
