### PR TITLE
[codex] Document analysis-owned artifact handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This package centers on reproducible analysis workflows with a small top-level A
 - Embedding maps (PCA, t-SNE, UMAP, PaCMAP, TriMap) with clustering, comparison, and trajectory-plotting helpers
 - Statistical wrappers (group comparisons, OLS regression, mixed-effects models, nonparametrics, and power)
 - Runtime provenance capture for reproducibility manifests
+- An analysis-owned artifact handoff in `design_research_analysis.integration`
 - A thin CLI for deterministic pipeline runs
 
 ## Quickstart
@@ -107,6 +108,7 @@ The supported public surface is whatever is exported from `design_research_analy
 Top-level exports include:
 
 - Package metadata: `__version__`
+- Artifact handoff helpers: `integration`, `load_experiment_artifacts`, `validate_experiment_events`
 - Table contracts: `UnifiedTableConfig`, `UnifiedTableValidationReport`, `coerce_unified_table`, `derive_columns`, `validate_unified_table`
 - Sequence: `fit_markov_chain_from_table`, `fit_discrete_hmm_from_table`, `fit_text_gaussian_hmm_from_table`, `decode_hmm`, plotting helpers, and result types
 - Language: `compute_language_convergence`, `compute_semantic_distance_trajectory`, `fit_topic_model`, `score_sentiment`

--- a/docs/experiments_handoff.rst
+++ b/docs/experiments_handoff.rst
@@ -5,6 +5,9 @@ Use this guide when you already have study artifacts exported from
 ``design-research-experiments`` and want the shortest reliable path into
 analysis.
 
+The analysis-owned cross-library handoff lives in
+``design_research_analysis.integration``.
+
 Why This Handoff Exists
 -----------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,11 +47,13 @@ Highlights
 - Embedding maps and clustering for embedding-space inspection
 - Statistical workflows for comparisons, regression, mixed effects, and power
 - Runtime provenance capture for reproducible study artifacts
+- An analysis-owned artifact handoff in ``design_research_analysis.integration``
 
 Typical Workflow
 ----------------
 
-1. Start from a unified event table or an exported
+1. Start from a unified event table or from
+   ``design_research_analysis.integration`` over an exported
    ``design-research-experiments`` ``events.csv`` artifact.
 2. Validate and, when needed, derive missing analysis columns.
 3. Run sequence, language, embedding-map, and/or statistical workflows.


### PR DESCRIPTION
## What changed
- document `design_research_analysis.integration` as the analysis-owned cross-library handoff surface
- clarify the experiments-to-analysis handoff guidance around canonical artifacts and owner-owned seam responsibility
- refresh README and index guidance to match the package-owned integration model

## Why
The ecosystem docs should make it obvious that analysis owns the artifact handoff boundary instead of relying on informal cross-repo conventions.

## Impact
Users following the docs will land on the stable `integration` surface when consuming experiment artifacts.

## Validation
- `PYTHONPATH=src uv run --python 3.12 python -m pytest -q tests/test_integration.py tests/test_public_api.py`
