### PR TITLE
[codex] Prepare Resnik Readout release version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 <!-- release-callout:start -->
 > [!IMPORTANT]
-> Current monthly release: [Carnegie Calculus - May 2026](https://github.com/cmudrc/design-research-analysis/milestone/3)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
+> Current monthly release: [Resnik Readout - June 2026](https://github.com/cmudrc/design-research-analysis/milestone/4)  
+> Due: July 1, 2026  
+> Tracks: June 2026 work
 <!-- release-callout:end -->
 
 `design-research-analysis` is the unified-table analysis layer in the cmudrc design research ecosystem.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "design-research-analysis"
-version = "0.2.0"
+version = "0.2.1"
 description = "Utilities for design research analysis workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from design_research_analysis.dataset import (
@@ -42,6 +44,56 @@ def test_profile_dataframe_accepts_csv_path(tmp_path) -> None:
 
     assert profile["n_rows"] == 2
     assert set(profile["columns"]) == {"score", "group"}
+
+
+def test_profile_dataframe_file_formats_and_dtype_edges(tmp_path) -> None:
+    tsv_path = tmp_path / "dataset.tsv"
+    pd.DataFrame(
+        {
+            "flag": [True, False],
+            "when": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            "category": pd.Series(["a", "b"], dtype="category"),
+            "ratio": [0.1, 0.2],
+        }
+    ).to_csv(tsv_path, sep="\t", index=False)
+
+    profile = profile_dataframe(tsv_path)
+    assert profile["columns"]["flag"]["inferred_dtype"] == "boolean"
+    assert profile["columns"]["when"]["inferred_dtype"] == "string"
+    assert profile["columns"]["ratio"]["inferred_dtype"] == "numeric"
+
+    typed_profile = profile_dataframe(
+        pd.DataFrame(
+            {
+                "category": pd.Series(["a", "b"], dtype="category"),
+                "when": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            }
+        )
+    )
+    assert typed_profile["columns"]["category"]["inferred_dtype"] == "category"
+    assert typed_profile["columns"]["when"]["inferred_dtype"] == "datetime"
+
+    columnar_json = tmp_path / "columnar.json"
+    columnar_json.write_text(json.dumps({"score": [1, 2], "group": ["a", "b"]}), encoding="utf-8")
+    assert profile_dataframe(columnar_json)["n_rows"] == 2
+
+    bad_rows = tmp_path / "bad-list.json"
+    bad_rows.write_text(json.dumps([1, 2]), encoding="utf-8")
+    with pytest.raises(ValueError, match="list of objects"):
+        profile_dataframe(bad_rows)
+
+    bad_payload = tmp_path / "bad-payload.json"
+    bad_payload.write_text(json.dumps("not rows"), encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON input"):
+        profile_dataframe(bad_payload)
+
+    unsupported = tmp_path / "dataset.xlsx"
+    unsupported.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported dataset input format"):
+        profile_dataframe(unsupported)
+
+    with pytest.raises(TypeError, match="Dataset input"):
+        profile_dataframe([{"score": 1}])  # type: ignore[arg-type]
 
 
 def test_validate_dataframe_reports_errors_and_warnings() -> None:
@@ -95,25 +147,69 @@ def test_validate_dataframe_accepts_json_path(tmp_path) -> None:
 def test_validate_dataframe_dtype_and_bound_errors() -> None:
     df = pd.DataFrame(
         {
+            "bad_rule": [1, 2],
+            "nullable": [1, None],
             "flag": ["yes", "no"],
             "score": ["high", "low"],
+            "low_score": [-1, 2],
+            "high_score": [1, 20],
             "group": ["A", "C"],
+            "literal": ["A", "B"],
+            "scalar_allowed": [1, 2],
             "code": ["bad", "X-2"],
+            "numeric_code": [1, 2],
+            "unknown_dtype": [1, 2],
         }
     )
     schema = {
+        "bad_rule": "not-a-mapping",
+        "nullable": {"nullable": False},
         "flag": {"dtype": "boolean"},
+        "literal": {"allowed": "A"},
+        "scalar_allowed": {"allowed": 1},
         "score": {"min": 0, "max": 10},
+        "low_score": {"min": 0},
+        "high_score": {"max": 10},
         "group": {"allowed": ["A", "B"]},
         "code": {"regex": r"X-\d"},
+        "numeric_code": {"regex": r"\d"},
         "unknown_dtype": {"dtype": "imaginary"},
     }
     result = validate_dataframe(df, schema)
     assert result["ok"] is False
+    assert any("must be a mapping" in err for err in result["errors"])
+    assert any("contains null values" in err for err in result["errors"])
     assert any("does not match declared dtype" in err for err in result["errors"])
+    assert any("unsupported dtype" in err for err in result["errors"])
     assert any("cannot use 'min'" in err for err in result["errors"])
+    assert any("below the allowed minimum" in err for err in result["errors"])
+    assert any("above the allowed maximum" in err for err in result["errors"])
     assert any("outside the allowed set" in err for err in result["errors"])
+    assert any("cannot use 'regex'" in err for err in result["errors"])
     assert any("fail regex validation" in err for err in result["errors"])
+
+
+def test_validate_dataframe_dtype_success_variants() -> None:
+    df = pd.DataFrame(
+        {
+            "label": ["a", "b"],
+            "category": pd.Series(["a", "b"], dtype="category"),
+            "flag": [True, False],
+            "when": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+        }
+    )
+
+    result = validate_dataframe(
+        df,
+        {
+            "label": {"dtype": "string"},
+            "category": {"dtype": "category"},
+            "flag": {"dtype": "boolean"},
+            "when": {"dtype": "datetime"},
+        },
+    )
+
+    assert result["ok"] is True
 
 
 def test_generate_codebook_preserves_order_and_descriptions() -> None:

--- a/tests/test_dimred_additional.py
+++ b/tests/test_dimred_additional.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import importlib.util
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -13,7 +14,12 @@ from design_research_analysis.embedding_maps import (
     _kmeans,
     build_embedding_map,
     cluster_embedding_map,
+    compare_embedding_maps,
+    compute_design_space_coverage,
+    compute_idea_space_trajectory,
     embed_records,
+    plot_embedding_map,
+    plot_embedding_map_grid,
 )
 
 
@@ -106,6 +112,15 @@ def test_embed_records_validation_errors() -> None:
             embedder=lambda texts: np.asarray([[1.0, 2.0], [3.0, 4.0]]),
         )
 
+    with pytest.raises(ValueError, match="record_id values must be unique"):
+        embed_records(
+            [
+                {"timestamp": "2026-01-01T10:00:00Z", "text": "hello", "record_id": "same"},
+                {"timestamp": "2026-01-01T10:00:01Z", "text": "again", "record_id": "same"},
+            ],
+            embedder=lambda texts: np.asarray([[1.0, 2.0], [3.0, 4.0]]),
+        )
+
 
 def test_embed_records_builtin_provider_uses_embed_text(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
@@ -154,9 +169,62 @@ def test_build_embedding_map_validation_and_constant_pca_case() -> None:
         build_embedding_map(np.ones((2, 2)), method="pca", n_components=0)
     with pytest.raises(ValueError, match="Unsupported method"):
         build_embedding_map(np.ones((2, 2)), method="bogus")
+    with pytest.raises(ValueError, match="record_ids length"):
+        build_embedding_map(np.ones((2, 2)), method="pca", record_ids=["r1"])
+    with pytest.raises(ValueError, match="record_ids must be unique"):
+        build_embedding_map(np.ones((2, 2)), method="pca", record_ids=["r1", "r1"])
 
     constant = build_embedding_map(np.ones((3, 2)), method="pca", n_components=2)
     assert constant.explained_variance_ratio == [0.0, 0.0]
+
+    with pytest.raises(ValueError, match="methods must contain"):
+        compare_embedding_maps(np.ones((2, 2)), methods=[])
+    with pytest.raises(ValueError, match="methods must be unique"):
+        compare_embedding_maps(np.ones((2, 2)), methods=["pca", "PCA"])
+
+
+def test_design_space_coverage_accepts_result_objects_and_degenerate_geometry() -> None:
+    embedding = EmbeddingResult(
+        embeddings=np.asarray([[0.0, 0.0, 0.0]]),
+        record_ids=["r1"],
+        texts=["one"],
+    )
+    singleton = compute_design_space_coverage(embedding)
+
+    assert singleton["config"]["input_source"] == "embedding_result"
+    assert singleton["pairwise_spread"]["n_pairs"] == 0
+    assert singleton["warnings"]
+
+    mapped = EmbeddingMapResult(
+        coordinates=np.asarray([[0.0, 0.0], [1.0, 1.0]]),
+        record_ids=["r1", "r2"],
+        method="pca",
+    )
+    two_points = compute_design_space_coverage(mapped)
+    assert two_points["config"]["input_source"] == "embedding_map_result"
+    assert two_points["convex_hull"]["supported"] is False
+
+    collinear = compute_design_space_coverage(np.asarray([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]))
+    assert collinear["convex_hull"]["area"] is None
+    assert any("collinear" in warning for warning in collinear["warnings"])
+
+    with pytest.raises(ValueError, match="finite numeric values"):
+        compute_design_space_coverage(np.asarray([[0.0, np.inf]]))
+
+
+def test_idea_space_trajectory_singletons_and_input_validation() -> None:
+    trajectory = compute_idea_space_trajectory(
+        np.asarray([[0.0, 0.0], [1.0, 1.0]]),
+        timestamps=[np.int64(2), None],
+        groups=["A", ""],
+    )
+
+    assert trajectory["groups"]["A"]["net_displacement"] == 0.0
+    assert trajectory["groups"]["__all__"]["ordered_timestamps"] == [None]
+    assert len(trajectory["warnings"]) == 2
+
+    with pytest.raises(ValueError, match="timestamps must have the same length"):
+        compute_idea_space_trajectory(np.ones((2, 2)), timestamps=[1])
 
 
 @pytest.mark.skipif(
@@ -224,3 +292,92 @@ def test_kmeans_validation_and_import_errors(monkeypatch: pytest.MonkeyPatch) ->
         cluster_embedding_map(np.ones((4, 2)), method="kmeans")
     with pytest.raises(ImportError, match="optional dependencies"):
         cluster_embedding_map(np.ones((4, 2)), method="agglomerative")
+
+
+def test_plot_embedding_map_validation_edges() -> None:
+    embedding_map = EmbeddingMapResult(
+        coordinates=np.asarray([[0.0, 0.0], [1.0, 1.0]]),
+        record_ids=["r1", "r2"],
+        method="pca",
+    )
+    rows = [
+        {"record_id": "r1", "trace": "t", "step": "1", "value": "1.0"},
+        {"record_id": "r2", "trace": "t", "step": "2", "value": "1.0"},
+    ]
+
+    fig, ax = plt.subplots()
+    returned_fig, returned_ax = plot_embedding_map(embedding_map, rows, value_column="value", ax=ax)
+    assert returned_fig is fig
+    assert returned_ax is ax
+    plt.close(fig)
+
+    with pytest.raises(ValueError, match="plotting requires a 2D embedding map"):
+        plot_embedding_map(
+            EmbeddingMapResult(
+                coordinates=np.ones((2, 3)),
+                record_ids=["r1", "r2"],
+                method="pca",
+            ),
+            rows,
+        )
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="order_column is required"):
+        plot_embedding_map(embedding_map, rows, trace_column="trace")
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="missing 'record_id'"):
+        plot_embedding_map(embedding_map, [{"trace": "t", "step": 1, "value": 1.0}])
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="Duplicate record_id"):
+        plot_embedding_map(embedding_map, [rows[0], rows[0]])
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="missing map record IDs"):
+        plot_embedding_map(embedding_map, [rows[0]])
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="missing 'value'"):
+        plot_embedding_map(embedding_map, [{**rows[0], "value": ""}, rows[1]], value_column="value")
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="non-numeric 'value'"):
+        plot_embedding_map(
+            embedding_map,
+            [{**rows[0], "value": "bad"}, rows[1]],
+            value_column="value",
+        )
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="missing 'trace'"):
+        plot_embedding_map(
+            embedding_map,
+            [{**rows[0], "trace": ""}, rows[1]],
+            trace_column="trace",
+            order_column="step",
+        )
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="missing 'step'"):
+        plot_embedding_map(
+            embedding_map,
+            [{**rows[0], "step": ""}, rows[1]],
+            trace_column="trace",
+            order_column="step",
+        )
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="non-numeric 'value'"):
+        plot_embedding_map(
+            embedding_map,
+            [{**rows[0], "value": "bad"}, rows[1]],
+            trace_column="trace",
+            order_column="step",
+            value_column="value",
+        )
+    plt.close("all")
+
+    with pytest.raises(ValueError, match="embedding_maps must contain"):
+        plot_embedding_map_grid({}, rows)
+    plt.close("all")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,6 +28,11 @@ def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
         writer.writerows(rows)
 
 
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
 def _write_canonical_artifacts(output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "manifest.json").write_text(
@@ -412,6 +417,52 @@ def test_build_run_metric_table_from_artifacts_rejects_blank_metric_names(
         build_run_metric_table_from_artifacts(output_dir, metrics=())
 
 
+def test_build_run_metric_table_from_artifacts_validation_edges(tmp_path: Path) -> None:
+    def make_output(name: str) -> Path:
+        output = tmp_path / name
+        _write_factorial_artifacts(output)
+        return output
+
+    missing_run_id = make_output("missing-run-id")
+    runs = _read_csv_rows(missing_run_id / "runs.csv")
+    runs[0]["run_id"] = ""
+    _write_csv(missing_run_id / "runs.csv", runs)
+    with pytest.raises(ValueError, match="missing 'run_id'"):
+        build_run_metric_table_from_artifacts(missing_run_id, metrics="quality_score")
+
+    missing_condition_id = make_output("missing-condition-id")
+    runs = _read_csv_rows(missing_condition_id / "runs.csv")
+    runs[0]["condition_id"] = ""
+    _write_csv(missing_condition_id / "runs.csv", runs)
+    with pytest.raises(ValueError, match="missing 'condition_id'"):
+        build_run_metric_table_from_artifacts(missing_condition_id, metrics="quality_score")
+
+    unknown_condition_id = make_output("unknown-condition-id")
+    runs = _read_csv_rows(unknown_condition_id / "runs.csv")
+    runs[0]["condition_id"] = "missing"
+    _write_csv(unknown_condition_id / "runs.csv", runs)
+    with pytest.raises(ValueError, match="references unknown condition_id"):
+        build_run_metric_table_from_artifacts(unknown_condition_id, metrics="quality_score")
+
+    no_metric = make_output("no-metric")
+    with pytest.raises(ValueError, match="No metric 'missing_score'"):
+        build_run_metric_table_from_artifacts(no_metric, metrics="missing_score")
+
+    duplicate_metric = make_output("duplicate-metric")
+    evaluations = _read_csv_rows(duplicate_metric / "evaluations.csv")
+    evaluations.append(dict(evaluations[0]))
+    _write_csv(duplicate_metric / "evaluations.csv", evaluations)
+    with pytest.raises(ValueError, match="Multiple metric rows"):
+        build_run_metric_table_from_artifacts(duplicate_metric, metrics="quality_score")
+
+    missing_metric_value = make_output("missing-metric-value")
+    evaluations = _read_csv_rows(missing_metric_value / "evaluations.csv")
+    evaluations[0]["metric_value"] = ""
+    _write_csv(missing_metric_value / "evaluations.csv", evaluations)
+    with pytest.raises(ValueError, match="missing a value"):
+        build_run_metric_table_from_artifacts(missing_metric_value, metrics="quality_score")
+
+
 def test_build_event_table_from_artifacts_rejects_missing_requested_context(
     tmp_path: Path,
 ) -> None:
@@ -420,6 +471,61 @@ def test_build_event_table_from_artifacts_rejects_missing_requested_context(
 
     with pytest.raises(ValueError, match="missing requested columns"):
         build_event_table_from_artifacts(output_dir, condition_columns=("missing_factor",))
+
+
+def test_build_event_table_from_artifacts_handles_session_fallback_and_context_conflicts(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "study-output"
+    _write_factorial_artifacts(output_dir)
+    events = _read_csv_rows(output_dir / "events.csv")
+    events[0]["run_id"] = ""
+    events[0]["problem_family"] = "event-family"
+    _write_csv(output_dir / "events.csv", events)
+
+    rows = build_event_table_from_artifacts(output_dir)
+
+    assert rows[0]["run_id"] == "run-1"
+    assert rows[0]["problem_family"] == "event-family"
+    assert rows[0]["run_problem_family"] == "mechanical"
+
+
+def test_build_event_table_from_artifacts_join_error_paths(tmp_path: Path) -> None:
+    missing_run_dir = tmp_path / "missing-run"
+    _write_factorial_artifacts(missing_run_dir)
+    events = _read_csv_rows(missing_run_dir / "events.csv")
+    events[0]["run_id"] = ""
+    events[0]["session_id"] = ""
+    _write_csv(missing_run_dir / "events.csv", events)
+    with pytest.raises(ValueError, match="missing 'run_id' and 'session_id'"):
+        build_event_table_from_artifacts(missing_run_dir)
+
+    unknown_run_dir = tmp_path / "unknown-run"
+    _write_factorial_artifacts(unknown_run_dir)
+    events = _read_csv_rows(unknown_run_dir / "events.csv")
+    events[0]["run_id"] = "missing"
+    _write_csv(unknown_run_dir / "events.csv", events)
+    with pytest.raises(ValueError, match="references unknown run_id"):
+        build_event_table_from_artifacts(unknown_run_dir)
+
+    no_condition_dir = tmp_path / "no-condition"
+    _write_factorial_artifacts(no_condition_dir)
+    events = _read_csv_rows(no_condition_dir / "events.csv")
+    runs = _read_csv_rows(no_condition_dir / "runs.csv")
+    events[0]["condition_id"] = ""
+    runs[0]["condition_id"] = ""
+    _write_csv(no_condition_dir / "events.csv", events)
+    _write_csv(no_condition_dir / "runs.csv", runs)
+    with pytest.raises(ValueError, match="has no 'condition_id' context"):
+        build_event_table_from_artifacts(no_condition_dir)
+
+    unknown_condition_dir = tmp_path / "unknown-condition"
+    _write_factorial_artifacts(unknown_condition_dir)
+    events = _read_csv_rows(unknown_condition_dir / "events.csv")
+    events[0]["condition_id"] = "missing"
+    _write_csv(unknown_condition_dir / "events.csv", events)
+    with pytest.raises(ValueError, match="references unknown condition_id"):
+        build_event_table_from_artifacts(unknown_condition_dir)
 
 
 def test_fit_markov_chains_from_artifacts_rejects_missing_group_column(
@@ -493,3 +599,34 @@ def test_fit_regression_from_artifacts_can_use_evaluation_metric_predictors(
     )
 
     assert result.coefficients["quality_score"] == pytest.approx(1.0)
+
+
+def test_fit_regression_from_artifacts_predictor_validation_and_full_dummies(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "study-output"
+    _write_factorial_artifacts(output_dir)
+
+    with pytest.raises(ValueError, match="categorical_predictors must be a subset"):
+        fit_regression_from_artifacts(
+            output_dir,
+            outcome="quality_score",
+            predictors=("model_size_b",),
+            categorical_predictors=("task_family",),
+        )
+
+    with pytest.raises(ValueError, match="must be numeric or listed"):
+        fit_regression_from_artifacts(
+            output_dir,
+            outcome="quality_score",
+            predictors=("task_family",),
+        )
+
+    result = fit_regression_from_artifacts(
+        output_dir,
+        outcome="quality_score",
+        predictors=("task_family",),
+        categorical_predictors=("task_family",),
+        drop_first=False,
+    )
+    assert set(result.coefficients) == {"task_family[mechanical]", "task_family[thermal]"}

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 
+import numpy as np
 import pytest
 
 from design_research_analysis.language import (
     compute_language_convergence,
+    compute_semantic_distance_trajectory,
     fit_topic_model,
     score_sentiment,
 )
@@ -35,6 +37,90 @@ def test_compute_language_convergence_detects_converging_trend() -> None:
     assert result.slope_by_group["s1"] < 0.0
 
 
+def test_compute_language_convergence_handles_text_list_and_stable_trend() -> None:
+    """Text-list inputs should use the all-group path and stable slope branch."""
+
+    def _embed(texts: list[str]) -> np.ndarray:
+        assert texts == ["alpha", "beta"]
+        return np.asarray([[1.0, 0.0], [1.0, 0.0]])
+
+    result = compute_language_convergence(
+        ["alpha", "beta"],
+        window_size=1,
+        embedder=_embed,
+    )
+
+    assert result.groups == ["__all__"]
+    assert result.direction_by_group["__all__"] == "stable"
+    assert result.n_observations == 2
+    assert result.to_dict()["config"]["model_name"] == "custom"
+
+
+def test_compute_language_convergence_detects_diverging_trend() -> None:
+    """Positive semantic-distance slope should be labeled as diverging."""
+    rows = [
+        {"timestamp": "2026-01-01T10:00:00Z", "session_id": "s1", "text": "target-a"},
+        {"timestamp": "2026-01-01T10:00:01Z", "session_id": "s1", "text": "target-b"},
+        {"timestamp": "2026-01-01T10:00:02Z", "session_id": "s1", "text": "opposite"},
+        {"timestamp": "2026-01-01T10:00:03Z", "session_id": "s1", "text": "target-c"},
+    ]
+    lookup = {
+        "target-a": [1.0, 0.0],
+        "target-b": [1.0, 0.0],
+        "opposite": [-1.0, 0.0],
+        "target-c": [1.0, 0.0],
+    }
+
+    result = compute_language_convergence(
+        rows,
+        window_size=1,
+        embedder=lambda texts: [lookup[text] for text in texts],
+    )
+
+    assert result.direction_by_group["s1"] == "diverging"
+    assert result.slope_by_group["s1"] > 0.0
+
+
+def test_semantic_distance_trajectory_validates_inputs() -> None:
+    """Semantic trajectories should reject invalid window and embedder shapes."""
+    rows = [{"timestamp": "2026-01-01T10:00:00Z", "session_id": "s1", "text": "alpha"}]
+
+    with pytest.raises(ValueError, match="window_size"):
+        compute_semantic_distance_trajectory(rows, window_size=0, embedder=lambda texts: [[1.0]])
+
+    with pytest.raises(ValueError, match="2D embedding"):
+        compute_semantic_distance_trajectory(rows, embedder=lambda texts: [1.0])
+
+    with pytest.raises(ValueError, match="rows must match"):
+        compute_semantic_distance_trajectory(rows, embedder=lambda texts: [[1.0], [2.0]])
+
+
+def test_language_text_extraction_handles_mapper_and_blank_values() -> None:
+    """Table inputs should support derived text and raise on unresolved blanks."""
+    rows = [
+        {
+            "timestamp": "2026-01-01T10:00:00Z",
+            "session_id": "",
+            "event_type": "idea",
+            "description": "derived text",
+        }
+    ]
+
+    trajectories = compute_semantic_distance_trajectory(
+        rows,
+        window_size=2,
+        embedder=lambda texts: [[0.0, 0.0]],
+        text_mapper=lambda row: row["description"],
+    )
+    assert trajectories == {"__all__": []}
+
+    with pytest.raises(ValueError, match="missing text"):
+        compute_semantic_distance_trajectory(
+            [{"timestamp": "2026-01-01T10:00:00Z", "text": ""}],
+            embedder=lambda texts: [[1.0]],
+        )
+
+
 def test_score_sentiment_labels_expected_polarity() -> None:
     rows = [
         {"timestamp": "2026-01-01T10:00:00Z", "text": "great clear success"},
@@ -44,6 +130,30 @@ def test_score_sentiment_labels_expected_polarity() -> None:
 
     assert result["labels"][0] == "positive"
     assert result["labels"][1] == "negative"
+
+
+def test_score_sentiment_handles_neutral_and_empty_inputs() -> None:
+    """Sentiment scoring should keep empty-token and empty-input paths deterministic."""
+    neutral = score_sentiment(["12345", "balanced words"])
+    assert neutral["labels"] == ["neutral", "neutral"]
+    assert neutral["counts"]["neutral"] == 2
+
+    empty = score_sentiment([])
+    assert empty["n_documents"] == 0
+    assert empty["mean_score"] == 0.0
+    assert empty["std_score"] == 0.0
+
+
+def test_fit_topic_model_validates_basic_parameters() -> None:
+    """Topic modeling should reject invalid lightweight arguments before optional imports."""
+    with pytest.raises(ValueError, match="n_topics"):
+        fit_topic_model(["alpha"], n_topics=0)
+
+    with pytest.raises(ValueError, match="max_features"):
+        fit_topic_model(["alpha"], max_features=0)
+
+    with pytest.raises(ValueError, match="top_k_terms"):
+        fit_topic_model(["alpha"], top_k_terms=0)
 
 
 @pytest.mark.skipif(importlib.util.find_spec("sklearn") is None, reason="sklearn unavailable")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -5,7 +5,13 @@ import importlib.util
 import numpy as np
 import pytest
 
-from design_research_analysis.stats import compare_groups, fit_mixed_effects, fit_regression
+from design_research_analysis.stats import (
+    GroupComparisonResult,
+    MixedEffectsResult,
+    compare_groups,
+    fit_mixed_effects,
+    fit_regression,
+)
 
 
 @pytest.mark.skipif(importlib.util.find_spec("scipy") is None, reason="scipy unavailable")
@@ -18,6 +24,90 @@ def test_compare_groups_returns_expected_directionality() -> None:
     assert result.method == "ttest"
     assert result.group_means["B"] > result.group_means["A"]
     assert result.p_value < 0.05
+
+
+@pytest.mark.skipif(importlib.util.find_spec("scipy") is None, reason="scipy unavailable")
+def test_compare_groups_table_anova_kruskal_and_edge_methods() -> None:
+    rows = [
+        {"group": "A", "value": 1.0},
+        {"group": "A", "value": 1.1},
+        {"group": "B", "value": 2.0},
+        {"group": "B", "value": 2.1},
+        {"group": "C", "value": 3.0},
+        {"group": "C", "value": 3.1},
+    ]
+
+    anova = compare_groups(data=rows)
+    kruskal = compare_groups(data=rows, method="kruskal")
+
+    assert anova.method == "anova"
+    assert kruskal.method == "kruskal"
+    assert anova.effect_size > 0.0
+
+    constant = compare_groups([1.0, 1.0, 1.0, 1.0], ["A", "A", "B", "B"], method="ttest")
+    assert constant.effect_size == 0.0
+
+    singleton = compare_groups([1.0, 2.0], ["A", "B"], method="ttest")
+    assert singleton.effect_size == 0.0
+
+    flat = compare_groups([1.0, 1.0, 1.0, 1.0], ["A", "A", "B", "B"], method="anova")
+    assert flat.effect_size == 0.0
+
+    with pytest.raises(ValueError, match="Row 0 is missing"):
+        compare_groups(data=[{"group": "A"}])
+    with pytest.raises(ValueError, match="ttest requires exactly two groups"):
+        compare_groups(data=rows, method="ttest")
+    with pytest.raises(ValueError, match="Unsupported method"):
+        compare_groups(data=rows, method="bogus")
+
+
+def test_group_and_mixed_results_compare_on_aligned_fields() -> None:
+    left = GroupComparisonResult(
+        method="ttest",
+        statistic=2.0,
+        p_value=0.05,
+        effect_size=0.4,
+        group_means={"A": 1.0},
+        group_sizes={"A": 3},
+    )
+    right = GroupComparisonResult(
+        method="anova",
+        statistic=3.0,
+        p_value=0.01,
+        effect_size=0.7,
+        group_means={"B": 2.0},
+        group_sizes={"B": 4},
+    )
+
+    diff = left - right
+    assert diff.metric == "group_summary"
+    assert diff.details["group_labels"] == ["A", "B"]
+    assert diff.details["methods"] == ["ttest", "anova"]
+
+    mixed_left = MixedEffectsResult(
+        success=True,
+        backend="statsmodels",
+        formula="y ~ x",
+        group_column="subject",
+        params={"Intercept": 1.0},
+        aic=None,
+        bic=4.0,
+        log_likelihood=-1.0,
+    )
+    mixed_right = MixedEffectsResult(
+        success=False,
+        backend="statsmodels",
+        formula="y ~ z",
+        group_column="cohort",
+        params={"slope": 2.0},
+        aic=5.0,
+        bic=None,
+        log_likelihood=None,
+    )
+
+    mixed_diff = mixed_left - mixed_right
+    assert mixed_diff.metric == "mixed_effects_profile"
+    assert mixed_diff.details["parameter_names"] == ["Intercept", "slope"]
 
 
 def test_fit_regression_recovers_linear_relationship() -> None:
@@ -42,6 +132,18 @@ def test_fit_regression_input_validation() -> None:
         fit_regression(np.empty((0, 1)), np.empty((0,)))
     with pytest.raises(ValueError, match="feature_names length"):
         fit_regression([[1.0], [2.0]], [1.0, 2.0], feature_names=["a", "b"])
+
+
+def test_fit_regression_without_intercept_uses_default_feature_names() -> None:
+    result = fit_regression(
+        [[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]],
+        [3.0, 6.0, 9.0],
+        add_intercept=False,
+    )
+
+    assert result.intercept == 0.0
+    assert set(result.coefficients) == {"x0", "x1"}
+    assert result.config == {"add_intercept": False}
 
 
 @pytest.mark.skipif(
@@ -80,3 +182,5 @@ def test_fit_mixed_effects_validation_errors() -> None:
         fit_mixed_effects([], formula="y ~ x", group_column="g", backend="bad")
     with pytest.raises(ValueError, match="requires at least one row"):
         fit_mixed_effects([], formula="y ~ x", group_column="g")
+    with pytest.raises(ValueError, match="group_column 'missing'"):
+        fit_mixed_effects([{"g": "a", "y": 1.0, "x": 0.0}], formula="y ~ x", group_column="missing")

--- a/tests/test_stats_condition_pairs.py
+++ b/tests/test_stats_condition_pairs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from design_research_analysis import build_condition_metric_table, compare_condition_pairs
+from design_research_analysis.stats import ConditionComparisonReport
 
 
 def test_build_condition_metric_table_joins_conditions_for_run_metric() -> None:
@@ -117,6 +118,67 @@ def test_build_condition_metric_table_errors_on_missing_metric() -> None:
         )
 
 
+def test_build_condition_metric_table_validation_edges() -> None:
+    with pytest.raises(ValueError, match="runs table must contain at least one row"):
+        build_condition_metric_table([], metric="score")
+
+    with pytest.raises(ValueError, match="runs table row 0 is missing 'run_id'"):
+        build_condition_metric_table([{"condition": "A", "score": 1.0}], metric="score")
+
+    with pytest.raises(ValueError, match="missing direct condition column"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition": "", "score": 1.0}],
+            metric="score",
+        )
+
+    with pytest.raises(ValueError, match="no conditions table was provided"):
+        build_condition_metric_table([{"run_id": "run-1", "score": 1.0}], metric="score")
+
+    with pytest.raises(ValueError, match="missing 'condition_id'"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "score": 1.0}],
+            metric="score",
+            conditions=[{"condition_id": "cond-a", "condition": "A"}],
+        )
+
+    with pytest.raises(ValueError, match="references unknown condition_id"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition_id": "missing", "score": 1.0}],
+            metric="score",
+            conditions=[{"condition_id": "cond-a", "condition": "A"}],
+        )
+
+    with pytest.raises(ValueError, match="conditions row"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition_id": "cond-a", "score": 1.0}],
+            metric="score",
+            conditions=[{"condition_id": "cond-a", "condition": ""}],
+        )
+
+    with pytest.raises(ValueError, match="missing metric column"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition": "A", "score": ""}],
+            metric="score",
+        )
+
+    with pytest.raises(ValueError, match="no evaluations table was provided"):
+        build_condition_metric_table([{"run_id": "run-1", "condition": "A"}], metric="score")
+
+    with pytest.raises(ValueError, match="is missing 'run_id'"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition": "A"}],
+            metric="score",
+            evaluations=[{"metric_name": "score", "metric_value": 1.0}],
+        )
+
+    with pytest.raises(ValueError, match="is missing 'metric_value'"):
+        build_condition_metric_table(
+            [{"run_id": "run-1", "condition": "A"}],
+            metric="score",
+            evaluations=[{"run_id": "run-1", "metric_name": "score", "metric_value": ""}],
+        )
+
+
 def test_build_condition_metric_table_errors_on_duplicate_evaluation_metric_rows() -> None:
     runs = [{"run_id": "run-1", "condition_id": "cond-a"}]
     conditions = [{"condition_id": "cond-a", "selection_strategy": "neutral_prompt"}]
@@ -202,6 +264,7 @@ def test_compare_condition_pairs_sampled_fallback_and_pair_ordering() -> None:
         ("B", "C"),
     ]
     assert all(item.test_method == "sampled" for item in report.comparisons)
+    assert report.comparisons[0].test_name == "sampled_permutation_test"
 
     right_heavier = report.comparisons[-1]
     assert right_heavier.mean_difference < 0.0
@@ -210,6 +273,21 @@ def test_compare_condition_pairs_sampled_fallback_and_pair_ordering() -> None:
 
 
 def test_compare_condition_pairs_validation_errors() -> None:
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        compare_condition_pairs([{"condition": "A", "value": 1.0}], alternative="bad")
+    with pytest.raises(ValueError, match="alpha must be in"):
+        compare_condition_pairs([{"condition": "A", "value": 1.0}], alpha=1.0)
+    with pytest.raises(ValueError, match="exact_threshold must be positive"):
+        compare_condition_pairs([{"condition": "A", "value": 1.0}], exact_threshold=0)
+    with pytest.raises(ValueError, match="n_permutations must be positive"):
+        compare_condition_pairs([{"condition": "A", "value": 1.0}], n_permutations=0)
+    with pytest.raises(ValueError, match="comparison table must contain at least one row"):
+        compare_condition_pairs([])
+    with pytest.raises(ValueError, match="missing 'condition'"):
+        compare_condition_pairs([{"value": 1.0}])
+    with pytest.raises(ValueError, match="missing 'value'"):
+        compare_condition_pairs([{"condition": "A"}])
+
     with pytest.raises(ValueError, match="At least two conditions"):
         compare_condition_pairs([{"condition": "A", "value": 1.0}])
 
@@ -229,3 +307,43 @@ def test_compare_condition_pairs_validation_errors() -> None:
                 {"condition": "B", "metric": "score_b", "value": 2.0},
             ]
         )
+
+    valid_rows = [
+        {"condition": "A", "metric": "score", "value": 1.0},
+        {"condition": "B", "metric": "score", "value": 2.0},
+    ]
+    with pytest.raises(ValueError, match="condition_pairs\\[0\\] must contain exactly two"):
+        compare_condition_pairs(valid_rows, condition_pairs=[("A", "B", "C")])  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="compares 'A' against itself"):
+        compare_condition_pairs(valid_rows, condition_pairs=[("A", "A")])
+    with pytest.raises(ValueError, match="references unknown conditions"):
+        compare_condition_pairs(valid_rows, condition_pairs=[("A", "C")])
+    with pytest.raises(ValueError, match="duplicates pair"):
+        compare_condition_pairs(valid_rows, condition_pairs=[("A", "B"), ("A", "B")])
+
+
+def test_compare_condition_pairs_equal_means_less_alternative_and_empty_brief() -> None:
+    report = compare_condition_pairs(
+        [
+            {"condition": "A", "metric": "score", "value": 1.0},
+            {"condition": "A", "metric": "score", "value": 3.0},
+            {"condition": "B", "metric": "score", "value": 1.0},
+            {"condition": "B", "metric": "score", "value": 3.0},
+        ],
+        alternative="less",
+    )
+
+    comparison = report.comparisons[0]
+    assert comparison.higher_condition is None
+    assert comparison.test_method == "exact"
+    assert "significant=no" in report.render_brief()
+
+    empty = ConditionComparisonReport(
+        metric="score",
+        condition_column="condition",
+        metric_column="value",
+        alternative="two-sided",
+        alpha=0.05,
+        comparisons=(),
+    )
+    assert "No condition comparisons" in empty.render_brief()

--- a/tests/test_stats_nonparametric_power.py
+++ b/tests/test_stats_nonparametric_power.py
@@ -98,8 +98,19 @@ def test_bootstrap_ci_additional_paths() -> None:
     result = bootstrap_ci([1, 2, 3, 4], stat="median", n_resamples=200, seed=1)
     assert result["method_used"] == "percentile"
 
+    difference = bootstrap_ci(
+        [1, 2, 3, 4],
+        y=[2, 3, 4, 5],
+        stat="diff_medians",
+        n_resamples=200,
+        seed=4,
+    )
+    assert difference["estimate"] == -1.0
+
     with pytest.raises(ValueError, match="n_resamples must be positive"):
         bootstrap_ci([1, 2], n_resamples=0)
+    with pytest.raises(ValueError, match="x must contain at least one value"):
+        bootstrap_ci([], n_resamples=10)
     with pytest.raises(ValueError, match="ci must be in"):
         bootstrap_ci([1, 2], ci=1.0)
     with pytest.raises(ValueError, match="method must be one of"):
@@ -131,6 +142,12 @@ def test_bootstrap_bca_and_rank_test_variants() -> None:
     assert kr["test"] == "kruskal"
     fr = rank_tests_one_stop([1, 2], groups=[[1, 2], [1, 2], [2, 3]], kind="friedman")
     assert fr["test"] == "friedman"
+
+    auto_wilcoxon = rank_tests_one_stop([1, 2, 3], [1.1, 2.1, 3.1], paired=True)
+    assert auto_wilcoxon["test"] == "wilcoxon"
+
+    auto_friedman = rank_tests_one_stop([1, 2], groups=[[1, 2], [2, 3], [3, 4]], paired=True)
+    assert auto_friedman["test"] == "friedman"
 
 
 @pytest.mark.skipif(not _HAS_SCIPY, reason="scipy unavailable")
@@ -215,6 +232,16 @@ class _FakeOneSamplePower:
         return 0.84 if effect_size >= 0.3 else 0.6
 
 
+class _LowPower:
+    def solve_power(self, **kwargs) -> float:
+        _ = kwargs
+        return 10.0
+
+    def power(self, **kwargs) -> float:
+        _ = kwargs
+        return 0.1
+
+
 def test_power_functions_with_fake_engines(monkeypatch) -> None:
     monkeypatch.setattr(
         stats_module,
@@ -262,3 +289,20 @@ def test_power_input_validation_errors(monkeypatch) -> None:
         power_curve([], n=10, test="paired_t")
     with pytest.raises(ValueError, match="n must be greater than 1"):
         power_curve([0.2], n=1, test="paired_t")
+    with pytest.raises(ValueError, match="n must be greater than 1"):
+        minimum_detectable_effect(1, test="paired_t")
+
+
+def test_power_edge_allocation_and_unreachable_target(monkeypatch) -> None:
+    monkeypatch.setattr(
+        stats_module,
+        "_load_power_engines",
+        lambda: (_FakeTwoSamplePower(), _FakeOneSamplePower()),
+    )
+
+    curve = power_curve([0.4], n=2, test="two_sample_t", ratio=0.01)
+    assert curve.iloc[0]["power"] == 0.82
+
+    monkeypatch.setattr(stats_module, "_load_power_engines", lambda: (_LowPower(), _LowPower()))
+    with pytest.raises(ValueError, match="Target power is unreachable"):
+        minimum_detectable_effect(20, test="paired_t", power=0.8)


### PR DESCRIPTION
## Summary
- bump package metadata from 0.2.0 to 0.2.1
- update the README release callout for Resnik Readout - June 2026

## June closeout scope
Resnik Readout is now scoped to release cleanup:

- #41 was closed by PR #42.
- #15 and #4 were moved to Cathedral Calculus - July 2026.
- #5 and #8 were moved to Schenley Signals - August 2026.

## Validation
- uv run --extra dev --extra stats make qa

## Note
Plain `uv run --extra dev make qa` does not install SciPy, which the sampled permutation-test path needs. The validation above includes the `stats` extra.
