### PR TITLE
[codex] Document VS Code start path for analysis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 ## Development Setup
 
+For a step-by-step VS Code setup, including interpreter selection, optional
+`uv` usage, analysis extras, runtime caches, and troubleshooting, see
+[VS Code Start](docs/vscode_start.rst).
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This package centers on reproducible analysis workflows with a small top-level A
 
 Requires Python 3.12+.
 Maintainer workflows target Python `3.12` (`.python-version`).
+For a VS Code-oriented contributor setup, see
+[VS Code Start](docs/vscode_start.rst).
 
 Install from PyPI:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,6 +138,7 @@ Start Here
 - :doc:`typical_workflow`
 - :doc:`examples/index`
 - :doc:`api`
+- :doc:`vscode_start`
 - :doc:`automation_baseline`
 - `CONTRIBUTING.md <https://github.com/cmudrc/design-research-analysis/blob/HEAD/CONTRIBUTING.md>`_
 
@@ -170,6 +171,7 @@ Start Here
    api
    cli_reference
    dependencies_and_extras
+   vscode_start
    automation_baseline
 
 .. toctree::

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -1,0 +1,138 @@
+VS Code Start
+=============
+
+Use this path when opening ``design-research-analysis`` in VS Code for the first
+time. The commands are repo-local and assume Python 3.12 or newer.
+
+Requirements
+------------
+
+- Python 3.12 or newer. Maintainer workflows target the version in
+  ``.python-version``.
+- VS Code with the Python extension.
+- ``make`` available in the integrated terminal.
+- Optional: ``uv`` for faster virtual environment and package installs.
+
+Open the Repository
+-------------------
+
+Open the repository root folder in VS Code, not the parent ecosystem folder. The
+root should contain ``pyproject.toml``, ``Makefile``, ``src/``, ``tests/``, and
+``examples/``.
+
+Create an Environment
+---------------------
+
+Standard library setup:
+
+.. code-block:: bash
+
+   python -m venv .venv
+   source .venv/bin/activate
+
+On Windows PowerShell, use:
+
+.. code-block:: powershell
+
+   py -3.12 -m venv .venv
+   .venv\Scripts\Activate.ps1
+
+With ``uv``:
+
+.. code-block:: bash
+
+   uv venv --python 3.12
+   source .venv/bin/activate
+
+Install Development Dependencies
+--------------------------------
+
+Use the maintainer shortcut:
+
+.. code-block:: bash
+
+   make dev
+
+Equivalent ``pip`` command:
+
+.. code-block:: bash
+
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
+
+Equivalent ``uv`` command:
+
+.. code-block:: bash
+
+   uv pip install -e ".[dev]"
+
+Install optional extras only when a workflow needs them:
+
+.. code-block:: bash
+
+   python -m pip install -e ".[seq]"
+   python -m pip install -e ".[lang,embeddings]"
+   python -m pip install -e ".[maps]"
+   python -m pip install -e ".[stats,data]"
+
+Select the VS Code Interpreter
+------------------------------
+
+Run ``Python: Select Interpreter`` from the command palette and choose the
+interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
+path manually:
+
+- macOS/Linux: ``.venv/bin/python``
+- Windows: ``.venv\Scripts\python.exe``
+
+First Checks
+------------
+
+Run the checks from VS Code's integrated terminal:
+
+.. code-block:: bash
+
+   make test
+   make qa
+   make docs-check
+
+``make qa`` runs linting, formatting checks, type checks, and tests. Run
+``make coverage`` before merge when changing tested behavior.
+
+Deterministic Examples
+----------------------
+
+Run the compact deterministic example path from the integrated terminal:
+
+.. code-block:: bash
+
+   make run-example
+   make examples-test
+
+To run the primary script directly:
+
+.. code-block:: bash
+
+   PYTHONPATH=src python examples/basic_usage.py
+
+Runtime Caches
+--------------
+
+The Makefile keeps plotting and package caches under ``artifacts/runtime`` for
+local analysis workflows. The relevant environment variables are
+``MPLCONFIGDIR``, ``XDG_CACHE_HOME``, and ``MPLBACKEND``. Use
+``make runtime-cache`` if those directories need to be created manually.
+
+Troubleshooting
+---------------
+
+- If VS Code imports fail but the terminal works, reselect the ``.venv``
+  interpreter and reload the window.
+- If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
+  ``PYTHON=.venv/bin/python make test``.
+- If Windows activation is blocked, enable script execution for the current
+  user or use the VS Code Python extension's environment activation.
+- If a method-specific import is missing, install the matching optional extra
+  rather than ``all`` unless you need a broad local analysis workstation.
+- Avoid committing generated runtime output under ``artifacts/``,
+  ``docs/_build/``, or local virtual environment directories.


### PR DESCRIPTION
## Summary
- add repo-local VS Code start instructions for design-research-analysis
- link the guide from README, CONTRIBUTING, and the Sphinx docs index
- cover Python 3.12, venv/uv setup, dev install, optional extras, runtime caches, checks, examples, and troubleshooting

Closes #41

## Verification
- make docs-build PYTHON=/Users/work/Codex/var/tmp/design-research-libraries-maintenance/2026-06-01/verify-venv-py313/bin/python
- make docs-check PYTHON=/Users/work/Codex/var/tmp/design-research-libraries-maintenance/2026-06-01/verify-venv-py313/bin/python