### PR TITLE
[codex] Document VS Code example path for analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,39 +53,19 @@ merging.
 - Keep CLI outputs and reproducibility metadata stable unless a change
   explicitly updates the release contract.
 
-## Release Naming
+## Release Planning
 
-- Theme: Pittsburgh / CMU people, places, and institutions.
-- Monthly work-cycle names are shared across milestone titles, release PR
-  titles, and release branches.
-- Name the cycle for the month the work is done, not the later drop month.
-  - Milestone title / PR title: `{base name} - {Work month YYYY}`
-  - Release branch: slugified full title, for example
-    `mellon-metrics-april-2026`
-- Milestone due dates should land in the first week of the following month.
-- Milestone descriptions must use:
-  - `Work month: {Month YYYY}.`
-  - `Theme source: <url>`
-- Release PR bodies must repeat the same `Theme source:` link used on the
-  milestone and refer to the same work month named in the title.
-- Never reuse an exact base name or the same primary subject across any work
-  month or any of the four design-research module repos unless all four
-  `AGENTS.md` files are intentionally updated together.
-- Before adding a new release name, check the `Release Naming` tables in all
-  four repos to avoid repeats.
-
-| Work month | Target drop | Base name | Source subject |
-| --- | --- | --- | --- |
-| March 2026 | April 1, 2026 | Allegheny Analysis | Allegheny River |
-| April 2026 | May 1, 2026 | Mellon Metrics | Andrew Mellon |
-| May 2026 | June 1, 2026 | Carnegie Calculus | Andrew Carnegie |
-| June 2026 | July 1, 2026 | Resnik Readout | Judith Resnik |
-| July 2026 | August 1, 2026 | Cathedral Calculus | Cathedral of Learning |
-| August 2026 | September 1, 2026 | Schenley Signals | Schenley Park |
-| September 2026 | October 1, 2026 | Oakland Observations | Oakland, Pittsburgh |
-| October 2026 | November 1, 2026 | Nationality Notes | Nationality Rooms |
-| November 2026 | December 1, 2026 | Doherty Diagnostics | Doherty Hall |
-| December 2026 | January 1, 2027 | Tartan Trends | Carnegie Mellon Tartans |
+- Do not create monthly milestone naming tables, themed release PR names, or
+  calendar release branches as default maintenance.
+- Prefer small issue/PR-scoped planning and package version releases driven by
+  user-facing changes.
+- Use GitHub milestones only for explicit, short-lived initiatives with an
+  active owner; they are optional scheduling aids, not release gates.
+- Name release branches and release PRs for the version or concrete change set
+  they contain.
+- When publishing, update package metadata, docs, examples, and GitHub
+  Releases/PyPI notes as needed. Do not add README callouts that point to
+  monthly milestones.
 
 ## Keep This File Up To Date
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Development Setup
 
-For a step-by-step VS Code setup, including interpreter selection, optional
-`uv` usage, analysis extras, runtime caches, and troubleshooting, see
+For a step-by-step VS Code setup, including the PyPI install path, source
+checkout path, interpreter selection, analysis extras, runtime caches, and
+troubleshooting, see
 [VS Code Start](docs/vscode_start.rst).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ This package centers on reproducible analysis workflows with a small top-level A
 
 Requires Python 3.12+.
 Maintainer workflows target Python `3.12` (`.python-version`).
-For a VS Code-oriented contributor setup, see
+For a VS Code path that starts from PyPI and then shows the repository example
+workflow, see
 [VS Code Start](docs/vscode_start.rst).
 
 Install from PyPI:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-analysis.svg)](https://pypi.org/project/design-research-analysis/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-analysis.svg)](https://pypi.org/project/design-research-analysis/)
 
-<!-- release-callout:start -->
-> [!IMPORTANT]
-> Current monthly release: [Carnegie Calculus - May 2026](https://github.com/cmudrc/design-research-analysis/milestone/3)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
-<!-- release-callout:end -->
-
 `design-research-analysis` is the unified-table analysis layer in the cmudrc design research ecosystem.
 
 It provides typed, reusable workflows for sequence, language, embedding-map, and statistical analysis over recurring event logs.

--- a/docs/automation_baseline.rst
+++ b/docs/automation_baseline.rst
@@ -6,8 +6,8 @@ This page documents the shared docs and CI baseline for
 
 The analysis repo now matches the common module-repo posture: public docs stay
 in sync with README and examples, and example health is reported explicitly.
-Release state is tracked in GitHub milestones and release branches rather than
-generated README callouts.
+Release state is tracked through package versions, GitHub Releases, and focused
+PRs rather than generated README callouts or default monthly milestones.
 
 Shared Module Baseline
 ----------------------

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -1,8 +1,13 @@
-VS Code Start
-=============
+Run An Example In VS Code
+=========================
 
-Use this path when opening ``design-research-analysis`` in VS Code for the first
-time. The commands are repo-local and assume Python 3.12 or newer.
+Use this page when you want to try ``design-research-analysis`` in VS Code.
+Choose the installed-package path for a first user workflow, or the source
+checkout path when you want to run the repository's checked-in examples and
+development checks.
+
+The checked-in ``examples/`` directory lives in the repository source. Do not
+assume those files are present inside the PyPI wheel.
 
 Requirements
 ------------
@@ -10,73 +15,31 @@ Requirements
 - Python 3.12 or newer. Maintainer workflows target the version in
   ``.python-version``.
 - VS Code with the Python extension.
-- ``make`` available in the integrated terminal.
-- Optional: ``uv`` for faster virtual environment and package installs.
+- A VS Code integrated terminal.
 
-Open the Repository
--------------------
+Installed Package From PyPI
+---------------------------
 
-Open the repository root folder in VS Code, not the parent ecosystem folder. The
-root should contain ``pyproject.toml``, ``Makefile``, ``src/``, ``tests/``, and
-``examples/``.
+Open an empty folder in VS Code, then create and activate a virtual
+environment from ``Terminal > New Terminal``.
 
-Create an Environment
----------------------
-
-Standard library setup:
+On macOS or Linux:
 
 .. code-block:: bash
 
    python -m venv .venv
    source .venv/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install design-research-analysis
 
-On Windows PowerShell, use:
+On Windows PowerShell:
 
 .. code-block:: powershell
 
    py -3.12 -m venv .venv
-   .venv\Scripts\Activate.ps1
-
-With ``uv``:
-
-.. code-block:: bash
-
-   uv venv --python 3.12
-   source .venv/bin/activate
-
-Install Development Dependencies
---------------------------------
-
-Use the maintainer shortcut:
-
-.. code-block:: bash
-
-   make dev
-
-Equivalent ``pip`` command:
-
-.. code-block:: bash
-
-   python -m pip install --upgrade pip setuptools wheel
-   python -m pip install -e ".[dev]"
-
-Equivalent ``uv`` command:
-
-.. code-block:: bash
-
-   uv pip install -e ".[dev]"
-
-Install optional extras only when a workflow needs them:
-
-.. code-block:: bash
-
-   python -m pip install -e ".[seq]"
-   python -m pip install -e ".[lang,embeddings]"
-   python -m pip install -e ".[maps]"
-   python -m pip install -e ".[stats,data]"
-
-Select the VS Code Interpreter
-------------------------------
+   .\.venv\Scripts\Activate.ps1
+   python -m pip install --upgrade pip
+   python -m pip install design-research-analysis
 
 Run ``Python: Select Interpreter`` from the command palette and choose the
 interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
@@ -85,8 +48,68 @@ path manually:
 - macOS/Linux: ``.venv/bin/python``
 - Windows: ``.venv\Scripts\python.exe``
 
-First Checks
-------------
+Create ``analysis_example.py`` in the workspace folder:
+
+.. code-block:: python
+
+   from design_research_analysis import (
+       coerce_unified_table,
+       fit_markov_chain_from_table,
+       validate_unified_table,
+   )
+
+   rows = coerce_unified_table(
+       [
+           {"timestamp": "2026-01-01T00:00:00", "session_id": "s1", "actor_id": "a", "event_type": "ideate"},
+           {"timestamp": "2026-01-01T00:00:05", "session_id": "s1", "actor_id": "a", "event_type": "refine"},
+           {"timestamp": "2026-01-01T00:00:10", "session_id": "s1", "actor_id": "a", "event_type": "evaluate"},
+       ]
+   )
+
+   report = validate_unified_table(rows)
+   if not report.is_valid:
+       raise RuntimeError("; ".join(report.errors))
+
+   result = fit_markov_chain_from_table(rows)
+   print(result.states)
+
+Run the file with VS Code's ``Run Python File`` action, or run:
+
+.. code-block:: bash
+
+   python analysis_example.py
+
+Source Checkout For Repository Examples
+---------------------------------------
+
+Use this path when you want the checked-in examples, docs, tests, and optional
+development tooling.
+
+.. code-block:: bash
+
+   git clone https://github.com/cmudrc/design-research-analysis.git
+   cd design-research-analysis
+   python -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
+
+Equivalent maintainer shortcut:
+
+.. code-block:: bash
+
+   make dev
+
+Run the deterministic example path from the integrated terminal:
+
+.. code-block:: bash
+
+   make run-example
+   make examples-test
+   python examples/basic_usage.py
+
+First Development Checks
+------------------------
 
 Run the checks from VS Code's integrated terminal:
 
@@ -99,21 +122,17 @@ Run the checks from VS Code's integrated terminal:
 ``make qa`` runs linting, formatting checks, type checks, and tests. Run
 ``make coverage`` before merge when changing tested behavior.
 
-Deterministic Examples
-----------------------
+Optional Backends
+-----------------
 
-Run the compact deterministic example path from the integrated terminal:
-
-.. code-block:: bash
-
-   make run-example
-   make examples-test
-
-To run the primary script directly:
+Install optional extras only when a workflow needs them:
 
 .. code-block:: bash
 
-   PYTHONPATH=src python examples/basic_usage.py
+   python -m pip install -e ".[seq]"
+   python -m pip install -e ".[lang,embeddings]"
+   python -m pip install -e ".[maps]"
+   python -m pip install -e ".[stats,data]"
 
 Runtime Caches
 --------------
@@ -130,8 +149,8 @@ Troubleshooting
   interpreter and reload the window.
 - If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
   ``PYTHON=.venv/bin/python make test``.
-- If Windows activation is blocked, enable script execution for the current
-  user or use the VS Code Python extension's environment activation.
+- If Windows activation is blocked, switch the terminal profile to Command
+  Prompt and run ``.\.venv\Scripts\activate.bat``.
 - If a method-specific import is missing, install the matching optional extra
   rather than ``all`` unless you need a broad local analysis workstation.
 - Avoid committing generated runtime output under ``artifacts/``,


### PR DESCRIPTION
## Summary
- make the VS Code guide start with a PyPI install path and pasteable public-API example
- keep a separate source checkout path for repository examples, dev dependencies, checks, runtime caches, and optional extras
- update README and CONTRIBUTING links so the PyPI/source split is visible from the first-run path
- remove the README monthly release callout and AGENTS monthly release naming table
- reword automation baseline docs away from generated README callouts or default monthly milestones
- keep future release planning issue/PR-scoped, with GitHub milestones treated as optional short-lived aids rather than release gates

Refs cmudrc/design-research#22

## Verification
- PyPI smoke-tested the documented starter snippets in a clean virtualenv
- `make docs-check`
- `make docs-build`