### PR TITLE
Fix experiment schema 0.2 compatibility

### DIFF
--- a/docs/experiments_handoff.rst
+++ b/docs/experiments_handoff.rst
@@ -30,11 +30,12 @@ the run, condition, event, and evaluation joins internally.
 Artifact Contract Version
 -------------------------
 
-The current adapter supports experiment artifact schema ``0.1.0``. Every
-artifact-first helper validates ``manifest.json`` before reading tables and
-raises a clear error for missing or unsupported versions. This keeps schema
-changes explicit without importing ``design-research-experiments`` or coupling
-analysis code to its internal Python models.
+The current adapter supports experiment artifact schemas ``0.1.0`` and
+``0.2.0``. Every artifact-first helper validates ``manifest.json`` before
+reading tables and raises a clear error for missing or unsupported versions.
+This keeps schema changes explicit without importing
+``design-research-experiments`` or coupling analysis code to its internal
+Python models.
 
 Canonical Input Files
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "design-research-analysis"
-version = "0.3.0"
+version = "0.3.1"
 description = "Utilities for design research analysis workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/design_research_analysis/integration.py
+++ b/src/design_research_analysis/integration.py
@@ -27,7 +27,7 @@ _ANALYSIS_ARTIFACT_FILES = (
     "events.csv",
     "evaluations.csv",
 )
-_SUPPORTED_EXPERIMENT_SCHEMA_VERSIONS = frozenset({"0.1.0"})
+_SUPPORTED_EXPERIMENT_SCHEMA_VERSIONS = frozenset({"0.1.0", "0.2.0"})
 _CONDITION_CONTEXT_EXCLUDE_COLUMNS = frozenset(
     {
         "study_id",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,10 +28,10 @@ def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
         writer.writerows(rows)
 
 
-def _write_canonical_artifacts(output_dir: Path) -> None:
+def _write_canonical_artifacts(output_dir: Path, *, schema_version: str = "0.1.0") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "manifest.json").write_text(
-        json.dumps({"schema_version": "0.1.0", "study_id": "demo-study"}),
+        json.dumps({"schema_version": schema_version, "study_id": "demo-study"}),
         encoding="utf-8",
     )
     _write_csv(
@@ -231,12 +231,16 @@ def _write_factorial_artifacts(output_dir: Path) -> None:
     )
 
 
-def test_load_experiment_artifacts_reads_canonical_export_directory(tmp_path: Path) -> None:
+@pytest.mark.parametrize("schema_version", ["0.1.0", "0.2.0"])
+def test_load_experiment_artifacts_reads_supported_canonical_export(
+    tmp_path: Path, schema_version: str
+) -> None:
     output_dir = tmp_path / "study-output"
-    _write_canonical_artifacts(output_dir)
+    _write_canonical_artifacts(output_dir, schema_version=schema_version)
 
     artifacts = load_experiment_artifacts(output_dir)
 
+    assert artifacts["manifest.json"]["schema_version"] == schema_version
     assert artifacts["manifest.json"]["study_id"] == "demo-study"
     assert artifacts["runs.csv"][0]["run_id"] == "run-1"
     assert artifacts["events.csv"][0]["event_type"] == "assistant_output"
@@ -286,7 +290,7 @@ def test_load_experiment_artifacts_rejects_unsupported_schema_version(tmp_path: 
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match=r"Unsupported.*9\.0\.0.*0\.1\.0"):
+    with pytest.raises(ValueError, match=r"Unsupported.*9\.0\.0.*0\.1\.0, 0\.2\.0"):
         load_experiment_artifacts(output_dir)
 
 


### PR DESCRIPTION
## Summary
- accept canonical Experiments artifact schemas 0.1.0 and 0.2.0
- test both supported versions and preserve unknown-version rejection
- document the versioned handoff contract
- prepare patch release 0.3.1

## Validation
- `make ci`
- 95.02% line coverage
- API in Examples: 73/73
- wheel and sdist checks, isolated wheel import and CLI smoke

Closes #46